### PR TITLE
Make compatible with atom-text-editor shadow DOM

### DIFF
--- a/stylesheets/base.less
+++ b/stylesheets/base.less
@@ -5,11 +5,11 @@
 @import "ui-variables";
 @import "colors";
 
-.editor-colors {
+.editor-colors, :host {
   background-color: @white;
   color: @gray_dark; }
 
-.editor {
+.editor, :host {
   font-family: 'Espresso Mono', Inconsolata, Monaco, Consolas, 'Courier New', Courier, monospace;
 
   .invisible-character,


### PR DESCRIPTION
As discussed in our latest [blog post](http://blog.atom.io/2014/11/18/avoiding-style-pollution-with-the-shadow-dom.html), we'll be transitioning Atom's text editor to use the shadow DOM to avoid accidental styling conflicts. Since you have a really popular syntax theme, I thought I'd save you the trouble of reading through our [upgrade guide](https://atom.io/docs/v0.147.0/upgrading/upgrading-your-syntax-theme) and just make the changes for you. Please check to make sure everything works just in case I missed something specific to your theme, but this should be straightforward. Thanks!