### PR TITLE
Fix bracket matcher styling

### DIFF
--- a/stylesheets/base.less
+++ b/stylesheets/base.less
@@ -34,7 +34,7 @@
 
 }
 
-.bracket-matcher {
+.bracket-matcher .region {
   background-color: @light_blue;
   border-radius: 2px;
   border: 1px solid @blue;


### PR DESCRIPTION
See https://github.com/atom/bracket-matcher/pull/82 https://github.com/atom/atom/issues/4453

Now need to style the `.region` inside `.bracket-matcher`.